### PR TITLE
Update task_unblock.py

### DIFF
--- a/task_unblock.py
+++ b/task_unblock.py
@@ -4,7 +4,7 @@ from mathis_bot_tools import can_run
 
 
 def get_users(site):
-    cat = pywikibot.Category(site, 'Catégorie:Demande de déblocage')
+    cat = pywikibot.Category(site, u'Catégorie:Demande de déblocage')
     gen = pagegenerators.CategorizedPageGenerator(cat)
     return [user.title(with_ns=False) for user in gen if user.namespace() == 3]
 

--- a/task_unblock.py
+++ b/task_unblock.py
@@ -4,15 +4,9 @@ from mathis_bot_tools import can_run
 
 
 def get_users(site):
-    cat = pywikibot.Category(site, u'Catégorie:Demande de déblocage')
+    cat = pywikibot.Category(site, 'Catégorie:Demande de déblocage')
     gen = pagegenerators.CategorizedPageGenerator(cat)
-    users = list()
-
-    for user in gen:
-        users.append(user.title(with_ns=False))
-
-    return users
-
+    return [user.title(with_ns=False) for user in gen if user.namespace() == 3]
 
 def check_open_dd(text, user):
     match = u'== Demande de déblocage de %s ==' % user


### PR DESCRIPTION
- Added namespace filtering (ns 3 <=> user talk)
- Directly returns a list comprehension.
- [UNFIXED] Unless I'm wrong Python 3 doesn't need to specify  u'Catégorie:Demande de déblocage' [while Python 2 needs it].